### PR TITLE
fixed auto-resize bug in IE

### DIFF
--- a/src/ui/ProgressCircle.scss
+++ b/src/ui/ProgressCircle.scss
@@ -24,4 +24,22 @@
     cursor: pointer;
 }
 
+//fixes IE bug where the svg doesn't get auto resized automatically
+@media screen and (-ms-high-contrast: active),
+(-ms-high-contrast: none) {
+    .widget-progress-circle > div {
+        height: 0;
+        padding: 0;
+        width: 100%;
+        padding-bottom: 100%;
+
+        & > svg {
+            top: 0;
+            left: 0;
+            height: 100%;
+            position: absolute;
+        }
+    }
+}
+
 @import "progress-circle-theme";


### PR DESCRIPTION
Fixes bug where the height of the svg isn't set to 100% automatically in IE. See screenshots.

![progress-circle_ie](https://user-images.githubusercontent.com/39378616/41229157-4c6c6cf8-6d7b-11e8-9545-84c9921feca2.png)
![progress-circle_chrome](https://user-images.githubusercontent.com/39378616/41229160-4ed576f6-6d7b-11e8-9b7e-7f2708581fc7.png)
