### PR TITLE
added overshoot value color feature to the widget

### DIFF
--- a/src/ProgressCircle.webmodeler.ts
+++ b/src/ProgressCircle.webmodeler.ts
@@ -24,6 +24,7 @@ export class preview extends Component<ContainerProps, {}> {
             displayTextValue: this.getDisplayTextValue(),
             maximumValue: props.staticMaximumValue,
             positiveValueColor: props.positiveValueColor,
+            overshootValueColor: props.overshootValueColor,
             style: ProgressCircleContainer.parseStyle(props.style),
             textSize: props.textSize,
             value: props.staticValue

--- a/src/ProgressCircle.xml
+++ b/src/ProgressCircle.xml
@@ -106,6 +106,20 @@
                 <enumerationValue key="danger">Danger</enumerationValue>
             </enumerationValues>
         </property>
+        <property key="overshootValueColor" type="enumeration" defaultValue="danger">
+            <caption>Overshoot style</caption>
+            <category>Appearance</category>
+            <description>Color of the circle with a overshooted progress value</description>
+            <enumerationValues>
+                <enumerationValue key="default">Default</enumerationValue>
+                <enumerationValue key="primary">Primary</enumerationValue>
+                <enumerationValue key="inverse">Inverse</enumerationValue>
+                <enumerationValue key="info">Info</enumerationValue>
+                <enumerationValue key="success">Success</enumerationValue>
+                <enumerationValue key="warning">Warning</enumerationValue>
+                <enumerationValue key="danger">Danger</enumerationValue>
+            </enumerationValues>
+        </property>
         <property key="circleThickness" type="integer" defaultValue="6">
             <caption>Circle thickness</caption>
             <category>Appearance</category>

--- a/src/components/ProgressCircle.ts
+++ b/src/components/ProgressCircle.ts
@@ -17,6 +17,7 @@ export interface ProgressCircleProps {
     negativeValueColor?: BootstrapStyle;
     onClickAction?: () => void;
     positiveValueColor?: BootstrapStyle;
+    overshootValueColor?: BootstrapStyle;
     style?: object;
     displayText?: DisplayText;
     textSize?: ProgressTextSize;
@@ -63,7 +64,7 @@ export class ProgressCircle extends Component<ProgressCircleProps, { alertMessag
     }
 
     render() {
-        const { maximumValue, textSize, negativeValueColor, positiveValueColor, value } = this.props;
+        const { maximumValue, textSize, negativeValueColor, positiveValueColor, overshootValueColor, value } = this.props;
         const textClass = textSize === "text" ? "mx-text" : textSize;
         const validMax = typeof maximumValue === "number" ? maximumValue > 0 : false;
         return createElement("div",
@@ -78,7 +79,8 @@ export class ProgressCircle extends Component<ProgressCircleProps, { alertMessag
                     this.progressCircleColorClass,
                     {
                         [`widget-progress-circle-${negativeValueColor}`]: value ? value < 0 : false,
-                        [`widget-progress-circle-${positiveValueColor}`]: value ? value > 0 : false,
+                        [`widget-progress-circle-${positiveValueColor}`]: value ? value > 0 && value < (maximumValue || 0) : false,
+                        [`widget-progress-circle-${overshootValueColor}`]: value ? value >= (maximumValue || 0) : false,
                         "widget-progress-circle-alert": !validMax,
                         "widget-progress-circle-clickable": this.props.clickable
                     }

--- a/src/components/ProgressCircleContainer.ts
+++ b/src/components/ProgressCircleContainer.ts
@@ -23,6 +23,7 @@ export interface ContainerProps extends WrapperProps {
     page?: string;
     progressAttribute: string;
     positiveValueColor: BootstrapStyle;
+    overshootValueColor: BootstrapStyle;
     textSize: ProgressTextSize;
     openPageAs: PageLocation;
     staticValue: number;
@@ -88,6 +89,7 @@ export default class ProgressCircleContainer extends Component<ContainerProps, C
             negativeValueColor: this.props.negativeValueColor,
             onClickAction: this.handleOnClick,
             positiveValueColor: this.props.positiveValueColor,
+            overshootValueColor: this.props.overshootValueColor,
             style: ProgressCircleContainer.parseStyle(this.props.style),
             textSize: this.props.textSize,
             value: this.props.progressAttribute ? this.state.progressValue || 0 : this.props.staticValue


### PR DESCRIPTION
Added a feature to set the progress circle color when the value overshoots the maximum value.
The setting appears in the appearance section of the widget, default value is set to danger, so it goes red when the value overshoots over the set maximum value.

This is helpful feature when we dynamically modify the value in the UI and expect the progress circle color to change when max value is reached, this feature helps to set the color on the value overshoot.

Please review the changes and merge the feature if its found useful. 